### PR TITLE
Check banner on host before generating it

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -25,16 +25,24 @@
     regexp: '^export PS1='
     line: export PS1='\[\033[00;31m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00;31m\]\$\[\033[00m\] '
 
-- name: "Generate MOTD banner"
-  ansible.builtin.shell: 'figlet "{{ ansible_hostname }}" -f slant -w 120 | lolcat -f'
-  delegate_to: localhost
-  become: false
-  register: motd
-  ignore_errors: yes
+- name: Check custom MOTD banner on host
+  ansible.builtin.stat:
+    path: /etc/update-motd.d/00-banner
+  register: stat_result
 
-- name: "Copy MOTD banner"
-  ansible.builtin.template:
-    src: 00-banner.j2
-    dest: /etc/update-motd.d/00-banner
-    mode: "755"
-  when: not motd.failed
+- name: Custom MOTD banner
+  when: not stat_result.stat.exists
+  block:
+    - name: "Generate MOTD banner"
+      ansible.builtin.shell: 'figlet "{{ ansible_hostname }}" -f slant -w 120 | lolcat -f'
+      delegate_to: localhost
+      become: false
+      register: motd
+      ignore_errors: yes
+
+    - name: "Copy MOTD banner"
+      ansible.builtin.template:
+        src: 00-banner.j2
+        dest: /etc/update-motd.d/00-banner
+        mode: "755"
+      when: not motd.failed


### PR DESCRIPTION
Check if the custom banner is on host before using figlet to generate a new one, to prevent `changed` state on `Generate MOTD banner` and `Copy MOTD banner` each time the common role is used.