### PR TITLE
chore: reuse just recipes in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,17 +19,18 @@ jobs:
           python-version: "3.12"
           cache: pip
 
+      - name: Setup just
+        uses: taiki-e/install-action@just
+
       - name: Create virtual environment and install dependencies
         run: |
-          python -m venv .venv
-          source ./.venv/bin/activate
-          pip install -r requirements.txt
+          just venv
           echo "PATH=$(pwd)/.venv/bin:${PATH}" >> "${GITHUB_ENV}"
           echo "VIRTUAL_ENV=$(pwd)/.venv" >> "${GITHUB_ENV}"
 
       - name: Run Ansible-Lint
         continue-on-error: true # Allow uploading SARIF report if ansible-lint is not happy
-        run: ansible-lint --offline --sarif-file ansible-lint.sarif.json # TODO: Reuse just lint
+        run: just lint --offline --sarif-file ansible-lint.sarif.json
 
       - name: Upload Ansible-Lint SARIF
         uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2 # v4.32.2


### PR DESCRIPTION
Petite PR pour réutiliser les recettes du justfile dans le worflow de test.

Vous pouvez juste fermer cette PR si vous pensez que c'est pas utile ou que vous avez une autre idée en tête.