### PR TITLE
chore(renovate): Change config for maximum version of python and pysnmp

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,16 @@
     {
       "matchPackageNames": ["ansible-lint", "ansible-cmdb"],
       "addLabels": ["development"]
+    },
+    {
+      "matchPackageNames": ["python"],
+      "allowedVersions": "<3.14" // Match debian 13 supported version
+    },
+    {
+      "matchPackageNames": ["pysnmp"],
+      // Match requirements for snmp_facts module (cf.
+      // docs.ansible.com/projects/ansible/latest/collections/community/general/snmp_facts_module.html)
+      "allowedVersions": "<6.2.4"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
Set max python version to `3.13.x` because this is last debian supported version.
Set max pysnmp to `6.2.3` because community.general.snmp_facts module does not support higher.