### PR TITLE
chore(renovate): Replace <3.14 with 3.13 in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
     },
     {
       "matchPackageNames": ["python"],
-      "allowedVersions": "<3.14" // Match debian 13 supported version
+      "allowedVersions": "3.13" // Match debian 13 supported version
     },
     {
       "matchPackageNames": ["pysnmp"],


### PR DESCRIPTION
Python version `<3.14` does not work so I replaced it with `3.13` to force the version