### PR TITLE
Ensure install with pip and pyproject.toml does not fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ ansible-lint.sarif.json
 
 # Python pycache
 **/__pycache__
+
+# Pyproject pip
+ansible_playbooks.egg-info/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ dev = [
     "ruff>=0.15.0",
     "ty>=0.0.16",
 ]
+
+[tool.setuptools]
+packages = []


### PR DESCRIPTION
Adds some stuff to `pyproject.toml` to avoid automatic discovery.