### PR TITLE
chore(roles/common): Use python environment lolcat and figlet

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 On the computer running the playbooks:
   - A Python virtualenv with the [requirements](./pyproject.toml) installed
-  - `figlet` and `lolcat-c` installed, to generate the ASCII art used in the MOTD banner
 
 On the managed servers:
   - An `ansible` user account with passwordless sudo (run the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ dependencies = [
     # community.general.snmp_facts doesn't support pysnmp 6.0+
     # https://github.com/ansible-collections/community.general/issues/8852
     "pysnmp<6.0.0",
+    "lolcat==1.4",
+    "pyfiglet==1.0.4"
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     # https://github.com/ansible-collections/community.general/issues/8852
     "pysnmp<6.0.0",
     "lolcat==1.4",
-    "pyfiglet==1.0.4"
+    "pyfiglet==1.0.4",
 ]
 
 [dependency-groups]

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -30,7 +30,7 @@
   become: true
 
 - name: Generate MOTD banner
-  ansible.builtin.shell: figlet {{ ansible_hostname | quote }} -f slant -w 120 | lolcat --force-color --seed {{ 65535 | random(seed=inventory_hostname) }}
+  ansible.builtin.shell: figlet {{ ansible_hostname | quote }} -f slant -w 120 | lolcat --force --seed {{ 65535 | random(seed=inventory_hostname) }}
   delegate_to: localhost
   become: false
   register: common_motd

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -30,7 +30,7 @@
   become: true
 
 - name: Generate MOTD banner
-  ansible.builtin.shell: figlet {{ ansible_hostname | quote }} -f slant -w 120 | lolcat --force --seed {{ 65535 | random(seed=inventory_hostname) }}
+  ansible.builtin.shell: pyfiglet {{ ansible_hostname | quote }} -f slant -w 120 | lolcat --force --seed {{ 65535 | random(seed=inventory_hostname) }}
   delegate_to: localhost
   become: false
   register: common_motd

--- a/uv.lock
+++ b/uv.lock
@@ -85,6 +85,8 @@ source = { virtual = "." }
 dependencies = [
     { name = "ansible" },
     { name = "hvac" },
+    { name = "lolcat" },
+    { name = "pyfiglet" },
     { name = "pysnmp" },
 ]
 
@@ -99,6 +101,8 @@ dev = [
 requires-dist = [
     { name = "ansible", specifier = "==12.3.0" },
     { name = "hvac", specifier = "==2.4.0" },
+    { name = "lolcat", specifier = "==1.4" },
+    { name = "pyfiglet", specifier = "==1.0.4" },
     { name = "pysnmp", specifier = "<6.0.0" },
 ]
 
@@ -402,6 +406,12 @@ wheels = [
 ]
 
 [[package]]
+name = "lolcat"
+version = "1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/bc/8d5907a28123202f21f9f3d679e00a4e7c2022c9b2fd415545b9fe02b7ff/lolcat-1.4.tar.gz", hash = "sha256:c65c2ed768e0bd0a97a7141865a62db6e8d3cd20742288d087f94c5ac86e8954", size = 44836, upload-time = "2019-05-14T07:22:40.965Z" }
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -523,6 +533,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pyfiglet"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/e3/0a86276ad2c383ce08d76110a8eec2fe22e7051c4b8ba3fa163a0b08c428/pyfiglet-1.0.4.tar.gz", hash = "sha256:db9c9940ed1bf3048deff534ed52ff2dafbbc2cd7610b17bb5eca1df6d4278ef", size = 1560615, upload-time = "2025-08-15T18:32:47.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/5c/fe9f95abd5eaedfa69f31e450f7e2768bef121dbdf25bcddee2cd3087a16/pyfiglet-1.0.4-py3-none-any.whl", hash = "sha256:65b57b7a8e1dff8a67dc8e940a117238661d5e14c3e49121032bd404d9b2b39f", size = 1806118, upload-time = "2025-08-15T18:32:45.556Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Use python figlet and lolcat 

- It enables a reproducible environment for running the motd banner generation
- It avoids problems regarding different version of lolcat with --force or --force-color options
- No longer requires to install system-wide packages in order to run the playbook properly