### PR TITLE
chore: update to Ansible 14

### DIFF
--- a/playbooks/deploy-server.yml
+++ b/playbooks/deploy-server.yml
@@ -6,7 +6,7 @@
     - firewall
     - monitoring
     - role: ntp
-      when: ansible_virtualization_type != "lxc"
+      when: ansible_facts['virtualization_type'] != "lxc"
     - ssh
     # - podman
     # - hestia

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,9 @@ description = "Rézoléo Ansible Playbooks"
 version = "0.1.0"
 requires-python = ">=3.13, <4"
 dependencies = [
-    "ansible==12.3.0",
+    "ansible==14.2.0",
     "hvac==2.4.0",
-    # community.general.snmp_facts doesn't support pysnmp 6.0+
-    # https://github.com/ansible-collections/community.general/issues/8852
-    "pysnmp<6.0.0",
+    "pysnmp==7.1.27",
     "lolcat==1.4",
     "pyfiglet==1.0.4",
 ]

--- a/renovate.json
+++ b/renovate.json
@@ -16,12 +16,6 @@
     {
       "matchPackageNames": ["python"],
       "allowedVersions": "3.13" // Match debian 13 supported version
-    },
-    {
-      "matchPackageNames": ["pysnmp"],
-      // Match requirements for snmp_facts module (cf.
-      // docs.ansible.com/projects/ansible/latest/collections/community/general/snmp_facts_module.html)
-      "allowedVersions": "<6.2.4"
     }
   ],
   "vulnerabilityAlerts": {

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -30,7 +30,7 @@
   become: true
 
 - name: Generate MOTD banner
-  ansible.builtin.shell: pyfiglet {{ ansible_hostname | quote }} -f slant -w 120 | lolcat --force --seed {{ 65535 | random(seed=inventory_hostname) }}
+  ansible.builtin.shell: pyfiglet {{ ansible_facts['hostname'] | quote }} -f slant -w 120 | lolcat --force --seed {{ 65535 | random(seed=inventory_hostname) }}
   delegate_to: localhost
   become: false
   register: common_motd

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -119,7 +119,7 @@
   delegate_to: localhost
   become: false
   ansible.builtin.uri:
-    url: https://librenms.rezoleo.fr/api/v0/devices/{{ ansible_hostname }}
+    url: https://librenms.rezoleo.fr/api/v0/devices/{{ ansible_facts['hostname'] }}
     method: GET
     return_content: true
     headers:
@@ -138,7 +138,7 @@
       X-Auth-Token: "{{ monitoring_librenms_api_token }}"
     body_format: json
     body:
-      hostname: "{{ ansible_hostname }}"
+      hostname: "{{ ansible_facts['hostname'] }}"
       overwrite_ip: "{{ inventory_hostname }}"
       version: v3
       authlevel: authPriv
@@ -153,7 +153,7 @@
   delegate_to: localhost
   become: false
   ansible.builtin.uri:
-    url: https://librenms.rezoleo.fr/api/v0/devices/{{ ansible_hostname }}
+    url: https://librenms.rezoleo.fr/api/v0/devices/{{ ansible_facts['hostname'] }}
     method: PATCH
     return_content: true
     headers:

--- a/roles/vault_agent/tasks/main.yml
+++ b/roles/vault_agent/tasks/main.yml
@@ -15,8 +15,13 @@
     group: root
 
 - name: Add Vault repository
-  ansible.builtin.apt_repository:
-    repo: "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.asc] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
+  ansible.builtin.deb822_repository:
+    name: hashicorp
+    types: deb
+    uris: https://apt.releases.hashicorp.com
+    suites: "{{ ansible_facts['distribution_release'] }}"
+    components: main
+    signed_by: /usr/share/keyrings/hashicorp-archive-keyring.asc
     state: present
 
 - name: Install Vault

--- a/uv.lock
+++ b/uv.lock
@@ -8,14 +8,14 @@ resolution-markers = [
 
 [[package]]
 name = "ansible"
-version = "12.3.0"
+version = "14.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ansible-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/df/60253bfc1f87e3d5b52a06723cc15270428dab113a878cd162ab3923db4e/ansible-12.3.0.tar.gz", hash = "sha256:02721f6fb432ddd47f1044ac49b04b5e9ae08890bd427def8df3db1607aeec51", size = 52065271, upload-time = "2025-12-09T21:04:42.344Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/8a/2800da95cacaabeda411db5bf54b97d1d953a03b5befc03a8a9486659ccb/ansible-14.2.0.tar.gz", hash = "sha256:1c8f18399027d26b0175270cb63bad99f9be16efe79600242c914eaa49941025", size = 50053376, upload-time = "2026-07-14T15:47:34.19Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/91/ed9ff629465050d4bdbc9da33d348156736b8778733f97a3627daae4f9ce/ansible-12.3.0-py3-none-any.whl", hash = "sha256:cd156f82fa87f7a899212b0efa9f7ca3a24d609212de9f78428a572eb01e5414", size = 54354494, upload-time = "2025-12-09T21:04:36.923Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/22/8847073941d543de5131f2130a68e4b6a437e613d5a23c257a7b01b93339/ansible-14.2.0-py3-none-any.whl", hash = "sha256:67f4c5c38f570ca9d87360964aaaea62f1a5eb2501e886b3dec1d67c9290618e", size = 49795074, upload-time = "2026-07-14T15:47:28.003Z" },
 ]
 
 [[package]]
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "ansible-core"
-version = "2.19.7"
+version = "2.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
@@ -45,9 +45,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "resolvelib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/53/f4/95c96c96c190955e9479a21b2ce52bf951e294784830f1db6975f8f6c479/ansible_core-2.19.7.tar.gz", hash = "sha256:7d6f53dc33fc3defbe437b88bfaf87b3f7abbc56c4f1691e59342166c70bbebd", size = 3422376, upload-time = "2026-02-23T23:05:27.415Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/6d/14fbdae14e7d02fd8349e6a52a76c144a1f92a2df3236c46bd7030cafdce/ansible_core-2.21.2.tar.gz", hash = "sha256:c6139e662eda1bfb5af16029f12afa5edfc7f95f8cd44281b1bdb434a6d9dc70", size = 3388984, upload-time = "2026-07-13T19:39:08.347Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/82/7e997eaf25940b082880bfa083215d3179a521350d99e12c6babb7a65c11/ansible_core-2.19.7-py3-none-any.whl", hash = "sha256:edeaadbff4eeaf0e677ae11b2ea9cc4faf9a250a59923a55e48fcb10cd66f35a", size = 2406327, upload-time = "2026-02-23T23:05:25.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/0c/c3f6f78d0e28123bec95a7d1a0caf8042c51042ce71db2816a290448863b/ansible_core-2.21.2-py3-none-any.whl", hash = "sha256:c7d696c717da03109a32a569a5fe57925812a86734344eab775cba169bf57cf8", size = 2456273, upload-time = "2026-07-13T19:39:06.668Z" },
 ]
 
 [[package]]
@@ -99,11 +99,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ansible", specifier = "==12.3.0" },
+    { name = "ansible", specifier = "==14.2.0" },
     { name = "hvac", specifier = "==2.4.0" },
     { name = "lolcat", specifier = "==1.4" },
     { name = "pyfiglet", specifier = "==1.0.4" },
-    { name = "pysnmp", specifier = "<6.0.0" },
+    { name = "pysnmp", specifier = "==7.1.27" },
 ]
 
 [package.metadata.requires-dev]
@@ -500,30 +500,12 @@ wheels = [
 ]
 
 [[package]]
-name = "ply"
-version = "3.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/69/882ee5c9d017149285cab114ebeab373308ef0f874fcdac9beb90e0ac4da/ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3", size = 159130, upload-time = "2018-02-15T19:01:31.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl", hash = "sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce", size = 49567, upload-time = "2018-02-15T19:01:27.172Z" },
-]
-
-[[package]]
 name = "pyasn1"
-version = "0.6.2"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/b6/6e630dff89739fcd427e3f72b3d905ce0acb85a45d4ec3e2678718a3487f/pyasn1-0.6.2.tar.gz", hash = "sha256:9b59a2b25ba7e4f8197db7686c09fb33e658b98339fadb826e9512629017833b", size = 146586, upload-time = "2026-01-16T18:04:18.534Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/b5/a96872e5184f354da9c84ae119971a0a4c221fe9b27a4d94bd43f2596727/pyasn1-0.6.2-py3-none-any.whl", hash = "sha256:1eb26d860996a18e9b6ed05e7aae0e9fc21619fcee6af91cca9bad4fbea224bf", size = 83371, upload-time = "2026-01-16T18:04:17.174Z" },
-]
-
-[[package]]
-name = "pyasyncore"
-version = "1.0.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/43/035dfe0cb01687c1940fdc008f46a43c41067e226e862df49327469764a0/pyasyncore-1.0.5.tar.gz", hash = "sha256:dd483d5103a6d59b66b86e0ca2334ad43dca732ff23a0ac5d63c88c52510542e", size = 15854, upload-time = "2026-01-05T19:59:31.893Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/ab/b10cee56269ae150763f3f83b3e9305a11f42f50b3dcd58eeb8f7988f0bb/pyasyncore-1.0.5-py3-none-any.whl", hash = "sha256:269bbc5252671827387636822841a1fb721ec6e858b23a3e12cf92eb1f97da2a", size = 10237, upload-time = "2026-01-05T19:59:30.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]
@@ -545,43 +527,15 @@ wheels = [
 ]
 
 [[package]]
-name = "pysmi"
-version = "1.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ply" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/82/36/5555ac1437d0e4159c0a7f7ce5b996e1aa56002b0c96f9a3d4fc6f39fd08/pysmi-1.2.1.tar.gz", hash = "sha256:4fc5a47279098f2fd79bbdfe51eedf5f078488ffad91604c2d4af5667a0f520c", size = 103707, upload-time = "2024-07-17T01:29:24.137Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/94/44c4c52a407c8241a8aaefe62acc9a5ad00a28a2c0339c22805b85a6272b/pysmi-1.2.1-py3-none-any.whl", hash = "sha256:d97c60de9f81d33ab2899124d95a94fa7fefacc86ab6e00cbfec543a073e6d33", size = 79980, upload-time = "2024-07-17T01:29:22.674Z" },
-]
-
-[[package]]
 name = "pysnmp"
-version = "5.1.0"
+version = "7.1.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyasn1" },
-    { name = "pyasyncore" },
-    { name = "pysmi" },
-    { name = "pysnmpcrypto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/91/8f9f41255a994f424432ff6808653699deaad843511f22342e6c03e9fac9/pysnmp-5.1.0.tar.gz", hash = "sha256:0285c1c87cdd56e63698138ccdf626308ee27c11129c1879a998f16f41551071", size = 403695, upload-time = "2024-07-17T01:44:33.421Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/6e/0d9c8a59ff4d6cb9c2477fe4cd106cb20cd6bbf008a0bca0c45ebb17aaad/pysnmp-7.1.27.tar.gz", hash = "sha256:01ce32d1bb0a14e8e3410a43fb7a8a7b050ec06186dc9ec240fcefa4af8b963c", size = 260310, upload-time = "2026-05-16T07:01:39.64Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/c0/701d1f43862245982e207bd28eca7c0889c62ca90012b23a64bb0f3eb9b4/pysnmp-5.1.0-py3-none-any.whl", hash = "sha256:375a8adfc6820faf24ace6761a6d20544e60580d714ff7266df272850c39b439", size = 290090, upload-time = "2024-07-17T01:44:31.323Z" },
-]
-
-[[package]]
-name = "pysnmpcrypto"
-version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/87/86a32362944ea2d554dce797f3988e9a9bdd24447b906c99d44d1f70506a/pysnmpcrypto-0.0.4.tar.gz", hash = "sha256:b635fb3b1ec6637b9a0033f50506214e16eb84574b1d25ab027bbde4caa55129", size = 7244, upload-time = "2018-12-29T23:07:01.273Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/ee/3ba0ddd4650ad5251479be614dacff65db920274f575825d48663a4ce7b9/pysnmpcrypto-0.0.4-py2.py3-none-any.whl", hash = "sha256:5889733caa030f45d9e03ea9d6370fb06426a8cb7f839aabbcdde33c6f634679", size = 6502, upload-time = "2018-12-29T23:06:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/be/d509cf05e5af40715aa4a562ee16d3c303433d451b6f768593e92e6796d7/pysnmp-7.1.27-py3-none-any.whl", hash = "sha256:314ad98d94d9ed445d4bb07721c374ec6ca4158fb41f92b9bc72feb9557513f7", size = 344440, upload-time = "2026-05-16T07:01:37.981Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fix deprecation warnings:
- apt_repository -> deb822_repository: ansible.builtin.apt_repository is deprecated in favor of ansible.builtin.deb822_repository and will be removed in ansible-core 2.25.
- ansible_* facts -> ansible_facts["..."] : same, would eventually have stopped working

Remove pysnmp restriction, the incompatibility is fixed !